### PR TITLE
make storm array functionality more accessible in C

### DIFF
--- a/src/platform/storm/libstormarray.c
+++ b/src/platform/storm/libstormarray.c
@@ -196,11 +196,58 @@ static int arr_set(lua_State *L)
     return 0;
 }
 
+int array_get_as2(storm_array_t *arr, int type, int idx, int *err)
+{
+  uint8_t rv [] __attribute__((aligned(4))) = {0,0,0,0};
+  uint8_t* ptr = ARR_START(arr) + idx;
+  *err = 0;
+  switch(type){
+  case GS_TYPE_INT16_BE:
+  case GS_TYPE_UINT16_BE:
+    rv[0] = ptr[1];
+    rv[1] = ptr[0];
+    break;
+  case GS_TYPE_INT32_BE:
+    rv[0] = ptr[3];
+    rv[1] = ptr[2];
+    rv[2] = ptr[1];
+    rv[3] = ptr[0];
+    break;
+  default: //little endian
+    rv[0] = ptr[0];
+    rv[1] = ptr[1];
+    rv[2] = ptr[2];
+    rv[3] = ptr[3];
+  }
+  switch(type){
+  case ARR_TYPE_INT8:
+    return *((int8_t*) &rv[0]);
+  case ARR_TYPE_UINT8:
+    return *((uint8_t*) &rv[0]);
+  case ARR_TYPE_INT16:
+  case GS_TYPE_INT16_BE:
+    return *((int16_t*) &rv[0]);
+  case ARR_TYPE_UINT16:
+  case GS_TYPE_UINT16_BE:
+    return *((uint16_t*) &rv[0]);
+  case ARR_TYPE_INT32:
+  case GS_TYPE_INT32_BE:
+    return *((int32_t*) &rv[0]);
+  default:
+    *err = 1;
+    return 0;
+  }
+}
+
+int array_get_as(storm_array_t *arr, int type, int idx){
+  int _;
+  return array_get_as2(arr, type, idx, &_);
+}
+
 //lua array:get_as(type, byte_idx)
 static int arr_get_as(lua_State *L)
 {
     int idx;
-    uint8_t* ptr;
     int type;
     uint8_t rv [] __attribute__((aligned(4))) = {0,0,0,0};
     storm_array_t *arr = lua_touserdata(L, 1);
@@ -214,50 +261,12 @@ static int arr_get_as(lua_State *L)
     {
         return luaL_error(L, "out of bounds");
     }
-    ptr = ARR_START(arr) + idx;
-    switch(type)
-    {
-        case GS_TYPE_INT16_BE:
-        case GS_TYPE_UINT16_BE:
-            rv[0] = ptr[1];
-            rv[1] = ptr[0];
-            break;
-        case GS_TYPE_INT32_BE:
-            rv[0] = ptr[3];
-            rv[1] = ptr[2];
-            rv[2] = ptr[1];
-            rv[3] = ptr[0];
-            break;
-        default: //little endian
-            rv[0] = ptr[0];
-            rv[1] = ptr[1];
-            rv[2] = ptr[2];
-            rv[3] = ptr[3];
+    int err;
+    int val = array_get_as2(arr, type, idx, &err);
+    if (err){
+      return luaL_error(L, "bad array type");
     }
-    switch(type)
-    {
-        case ARR_TYPE_INT8:
-            lua_pushnumber(L, *((int8_t*) &rv[0]));
-            break;
-        case ARR_TYPE_UINT8:
-            lua_pushnumber(L, *((uint8_t*) &rv[0]));
-            break;
-        case ARR_TYPE_INT16:
-        case GS_TYPE_INT16_BE:
-            lua_pushnumber(L, *((int16_t*) &rv[0]));
-            break;
-        case ARR_TYPE_UINT16:
-        case GS_TYPE_UINT16_BE:
-            lua_pushnumber(L, *((uint16_t*) &rv[0]));
-            break;
-        case ARR_TYPE_INT32:
-        case GS_TYPE_INT32_BE:
-            lua_pushnumber(L, *((int32_t*) &rv[0]));
-            break;
-        default:
-            return luaL_error(L, "bad array type");
-    }
-    return 1;
+    return val;
 }
 
 int array_get_length(storm_array_t *arr){

--- a/src/platform/storm/libstormarray.h
+++ b/src/platform/storm/libstormarray.h
@@ -25,4 +25,12 @@ enum {
 #define ARR_START(x) (((uint8_t*)((x)) + sizeof(storm_array_t)))
 int storm_array_nc_create(lua_State *L, int count, int type);
 
+int array_get(storm_array_t *arr, int idx);
+int array_set(storm_array_t *arr, int idx, int val);
+int array_get_length(storm_array_t *arr);
+
+int arr_as_str(lua_State *L);
+int arr_get_pstring(lua_State *L);
+int arr_set_pstring(lua_State *L);
+
 #endif

--- a/src/platform/storm/libstormarray.h
+++ b/src/platform/storm/libstormarray.h
@@ -28,6 +28,8 @@ int storm_array_nc_create(lua_State *L, int count, int type);
 int array_get(storm_array_t *arr, int idx);
 int array_set(storm_array_t *arr, int idx, int val);
 int array_get_length(storm_array_t *arr);
+int array_get_as(storm_array_t *arr, int type, int idx);
+int array_get_as2(storm_array_t *arr, int type, int idx, int *err);
 
 int arr_as_str(lua_State *L);
 int arr_get_pstring(lua_State *L);


### PR DESCRIPTION
This is still incomplete and there are a few points that I'm not sure about like
what kind of naming convention to use for c interface functions.

The non-static functions that where there would still push their result on to the stack.
The functions I added return the result directly and don't deal with the Lua state at all
because it fits my use cases better. Is this inconsistency ok? what method should
they all use?
