### PR TITLE
Redirection of Standard Output

### DIFF
--- a/src/newlib/genstd.c
+++ b/src/newlib/genstd.c
@@ -11,6 +11,7 @@
 #include <ctype.h>
 #include "utils.h"
 #include <interface.h>
+#include <libstorm.h>
 static p_std_send_char std_send_char_func;
 static p_std_get_char std_get_char_func;
 int std_prev_char = -1;
@@ -119,6 +120,7 @@ static _ssize_t std_write( struct _reent *r, int fd, const void* vptr, size_t le
     return -1;
   }  
   
+  libstorm_os_calloutputhook(vptr, len);
   k_write(1, (uint8_t*)vptr, len);
   return len;
 }

--- a/src/platform/storm/libstorm.c
+++ b/src/platform/storm/libstorm.c
@@ -525,6 +525,28 @@ int libstorm_os_gettable( lua_State *L )
     return 1;
 }
 
+int outputhookref = LUA_NOREF;
+// Lua: storm.os.setoutputhook(cb)
+int libstorm_os_setoutputhook(lua_State* L)
+{
+    _cb_L = L;
+    luaL_unref(L, LUA_REGISTRYINDEX, outputhookref);
+    if (lua_isnil(L, 1)) {
+        outputhookref = LUA_NOREF;
+    } else {
+        outputhookref = luaL_ref(L, LUA_REGISTRYINDEX);
+    }
+    return 0;
+}
+
+void libstorm_os_calloutputhook(const char* buffer, size_t length)
+{
+    if (outputhookref != LUA_NOREF) {
+        lua_rawgeti(_cb_L, LUA_REGISTRYINDEX, outputhookref);
+        lua_pushlstring(_cb_L, buffer, length);
+        lua_call(_cb_L, 1, 0);
+    }
+}
 
 // Lua: storm.io.set( value, pin1, pin2, ..., pinn )
 int libstorm_io_set( lua_State *L )
@@ -1631,6 +1653,7 @@ const LUA_REG_TYPE libstorm_os_map[] =
     { LSTRKEY( "lookuproute" ), LFUNCVAL ( libstorm_os_lookuproute ) },
     { LSTRKEY( "gettable" ), LFUNCVAL ( libstorm_os_gettable ) },
     { LSTRKEY( "setpowerlock"), LFUNCVAL ( libstorm_os_setpowerlock) },
+    { LSTRKEY( "setoutputhook" ), LFUNCVAL ( libstorm_os_setoutputhook ) },
     { LSTRKEY( "ROUTE_IFACE_ALL" ), LNUMVAL ( 0 ) },
     { LSTRKEY( "ROUTE_IFACE_154" ), LNUMVAL ( 1 ) },
     { LSTRKEY( "ROUTE_IFACE_PPP" ), LNUMVAL ( 2 ) },

--- a/src/platform/storm/libstorm.h
+++ b/src/platform/storm/libstorm.h
@@ -18,6 +18,7 @@ int libstorm_os_cancel( lua_State *L );
 int libstorm_os_now( lua_State *L );
 int libstorm_os_invoke_periodically(lua_State *L);
 int libstorm_os_invoke_later(lua_State *L);
+int libstorm_os_setoutputhook(lua_State* L);
 int libstorm_net_udpsocket(lua_State *L);
 int libstorm_net_close(lua_State *L);
 int libstorm_net_sendto(lua_State *L);
@@ -35,5 +36,7 @@ int libstorm_bl_enable(lua_State *L);
 int libstorm_bl_addservice(lua_State *L);
 int libstorm_bl_addcharacteristic(lua_State *L);
 int libstorm_bl_notify(lua_State *L);
+
+void libstorm_os_calloutputhook(const char* buffer, size_t length);
 
 #endif


### PR DESCRIPTION
This pull request implements the storm.os.outputhook call, that allows all writes to standard output (both Lua and C calls to print/printf) to be redirected to a custom function. This is useful for redirecting standard output into a TCP socket, as is done in the remote shell demo.
